### PR TITLE
Implement multi-model code scoring framework

### DIFF
--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "\n",
+    "import anthropic\n",
+    "\n",
+    "\n",
+    "def analyze_code_anthropic(code: str) -> dict:\n",
+    "    \"\"\"\n",
+    "    Analyzes code quality using Anthropic's Claude model.\n",
+    "\n",
+    "    Args:\n",
+    "        code (str): The code string to analyze.\n",
+    "\n",
+    "    Returns:\n",
+    "        dict: A dictionary containing code quality scores (0-100).\n",
+    "    \"\"\"\n",
+    "    if not code:\n",
+    "        return {\n",
+    "            \"vulnerability_score\": 0,\n",
+    "            \"style_score\": 0,\n",
+    "            \"quality_score\": 0,\n",
+    "        }\n",
+    "\n",
+    "    try:\n",
+    "        client = anthropic.Anthropic(api_key=os.environ.get(\"ANTHROPIC_API_KEY\"))\n",
+    "\n",
+    "        prompt = f\"\"\"Analyze the following code for vulnerabilities, style, and quality. \n",
+    "        Provide scores from 0-100 for each category in this exact JSON format:\n",
+    "        {{\n",
+    "            \"vulnerability_score\": <number>,\n",
+    "            \"style_score\": <number>,\n",
+    "            \"quality_score\": <number>\n",
+    "        }}\n",
+    "\n",
+    "        Code to analyze:\n",
+    "        ```\n",
+    "        {code}\n",
+    "        ```\n",
+    "        \"\"\"\n",
+    "\n",
+    "        response = client.messages.create(\n",
+    "            model=\"claude-sonnet-4-20250514\",\n",
+    "            max_tokens=1024,\n",
+    "            messages=[{\"role\": \"user\", \"content\": prompt}],\n",
+    "        )\n",
+    "\n",
+    "        result = json.loads(response.content[0].text)\n",
+    "        return result\n",
+    "\n",
+    "    except Exception as e:\n",
+    "        return {\n",
+    "            \"vulnerability_score\": 0,\n",
+    "            \"style_score\": 0,\n",
+    "            \"quality_score\": 0,\n",
+    "            \"error\": f\"Anthropic API error: {str(e)}\",\n",
+    "        }\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "code = \"\"\"\n",
+    "import json\n",
+    "import os\n",
+    "\n",
+    "import anthropic\n",
+    "from mistralai import Mistral\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "\n",
+    "def create_code_score(code: str) -> dict:\n",
+    "    if not code:\n",
+    "        return {\n",
+    "            \"vulnerability_score\": 0,\n",
+    "            \"style_score\": 0,\n",
+    "            \"quality_score\": 0,\n",
+    "        }\n",
+    "\n",
+    "    try:\n",
+    "        # Initialize AI clients\n",
+    "        anthropic_client = anthropic.Anthropic(\n",
+    "            api_key=os.environ.get(\"ANTHROPIC_API_KEY\")\n",
+    "        )\n",
+    "        mistral_client = Mistral(api_key=os.environ.get(\"MISTRAL_API_KEY\"))\n",
+    "        openai_client = OpenAI(api_key=os.environ.get(\"OPENAI_API_KEY\"))\n",
+    "    except Exception as e:\n",
+    "        return {\n",
+    "            \"vulnerability_score\": 0,\n",
+    "            \"style_score\": 0,\n",
+    "            \"quality_score\": 0,\n",
+    "        }\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'vulnerability_score': 0,\n",
+       " 'style_score': 0,\n",
+       " 'quality_score': 0,\n",
+       " 'error': 'Anthropic API error: Expecting value: line 1 column 1 (char 0)'}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "analyze_code_anthropic(code)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Looking at this code snippet, I\\'ll analyze it across the three requested categories:\\n\\n## Vulnerability Analysis\\n- **Missing API key validation**: The code retrieves API keys from environment variables but doesn\\'t validate they exist before using them, which could lead to runtime errors\\n- **Broad exception handling**: The generic `except Exception as e:` catches all exceptions but doesn\\'t log or handle them appropriately, potentially masking important errors\\n- **No input validation**: While there\\'s a basic empty string check, there\\'s no validation for code content type or size limits\\n- **Potential resource leaks**: Multiple AI clients are initialized but the code doesn\\'t show proper cleanup or resource management\\n\\n## Style Analysis\\n- **Good**: Follows PEP 8 naming conventions and has type hints\\n- **Good**: Clear function name and reasonable structure\\n- **Issues**: \\n  - Inconsistent spacing around imports (missing blank line separation)\\n  - The broad exception handling is not pythonic\\n  - Magic numbers in return dictionaries could be constants\\n  - Missing docstring for the function\\n\\n## Quality Analysis\\n- **Incomplete functionality**: The function is clearly unfinished - it initializes clients but doesn\\'t use them\\n- **Poor error handling**: Returns zeros for all scores on any error without indication of what went wrong\\n- **No logging**: No way to debug issues when they occur\\n- **Unclear requirements**: The function signature suggests it should analyze code but the implementation is incomplete\\n- **Resource inefficiency**: Creates multiple AI clients that aren\\'t used\\n\\n```json\\n{\\n    \"vulnerability_score\": 25,\\n    \"style_score\": 65,\\n    \"quality_score\": 20\\n}\\n```'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client = anthropic.Anthropic(api_key=os.environ.get(\"ANTHROPIC_API_KEY\"))\n",
+    "\n",
+    "prompt = f\"\"\"\n",
+    "Analyze the following code for vulnerabilities, style, and quality. \n",
+    "Provide scores from 0-100 for each category in this exact JSON format:\n",
+    "    \"vulnerability_score\": <number>,\n",
+    "    \"style_score\": <number>,\n",
+    "    \"quality_score\": <number>\n",
+    "Code to analyze:\n",
+    "```\n",
+    "{code}\n",
+    "```\n",
+    "\"\"\"\n",
+    "\n",
+    "response = client.messages.create(\n",
+    "    model=\"claude-sonnet-4-20250514\",\n",
+    "    max_tokens=1024,\n",
+    "    messages=[{\"role\": \"user\", \"content\": prompt}],\n",
+    "    \n",
+    ")\n",
+    "\n",
+    "response.content[0].text"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 python-dotenv>=1.1.0
 gradio==5.32.1
 gradio[mcp]==5.32.1
+mistralai==1.8.1
+openai==1.84.0
+anthropic==0.52.2

--- a/src/app.py
+++ b/src/app.py
@@ -18,7 +18,7 @@ analysis_report_demo = gr.Interface(
 code_score_demo = gr.Interface(
     fn=create_code_score,
     inputs=gr.Textbox(label="Enter Code Here", lines=20),
-    outputs=gr.Textbox(label="Code Score"),
+    outputs=gr.JSON(label="Code Score"),
     description="Generate a basic code score.",
 )
 

--- a/src/code_analyzer/scoring.py
+++ b/src/code_analyzer/scoring.py
@@ -1,15 +1,232 @@
-def create_code_score(code: str) -> str:
-    """
-    Placeholder function to generate a code score.
+import json
+import os
+from typing import Dict, Any
 
-    Args:
-        code (str): The code string to score.
+from anthropic import Anthropic
+from mistralai import Mistral
+from openai import OpenAI
+from pydantic import BaseModel, ValidationError
 
-    Returns:
-        str: A dummy code score.
+# ------------------------------------------------------------------ #
+# Configuration
+# ------------------------------------------------------------------ #
+
+DEFAULT_SCORES: Dict[str, Any] = {
+    "vulnerability_score": 0,
+    "style_score": 0,
+    "quality_score": 0,
+}
+
+ANALYSIS_PROMPT_TEMPLATE = (
+    "Analyze the following code for vulnerabilities, style, and quality "
+    "and return **only** a JSON object with keys "
+    "'vulnerability_score', 'style_score', and 'quality_score' "
+    "(each 0–100):\n```python\n{code}\n```"
+)
+
+SYSTEM_MESSAGES = {
+    "anthropic": "You are a secure-coding assistant. Assess code quality, style and vulnerabilities.",
+    "mistral": "You are a secure-coding assistant. Assess code quality, style and vulnerabilities.",
+    "openai": "You are a secure-coding assistant. Assess code quality, style and vulnerabilities.",
+}
+
+MODELS = {
+    "anthropic": "claude-opus-4-20250514",  # adjust if you use a different Claude-3 variant
+    "mistral": "mistral-medium-2505",
+    "openai": "gpt-4.1-2025-04-14",
+}
+
+REQUIRED_KEYS = ("vulnerability_score", "style_score", "quality_score")
+
+# ------------------------------------------------------------------ #
+# Helpers
+# ------------------------------------------------------------------ #
+
+
+class CodeAnalysisResult(BaseModel):
+    vulnerability_score: int
+    style_score: int
+    quality_score: int
+
+
+def _safe_json_loads(raw: str) -> Dict[str, Any]:
     """
+    Best-effort JSON parsing – fall back to DEFAULT_SCORES on failure.
+    """
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return DEFAULT_SCORES.copy()
+
+def _ensure_all_keys(d: dict, default: int = 0) -> dict:
+    """
+    Return a dict that has every REQUIRED_KEYS entry.
+    Missing keys are added with `default`.
+    Non-required keys are discarded.
+    """
+    return {key: int(d.get(key, default)) for key in REQUIRED_KEYS}
+
+# ------------------------------------------------------------------ #
+# Provider wrappers
+# ------------------------------------------------------------------ #
+
+
+def analyze_code_anthropic(code: str) -> dict:
     if not code:
-        return "Please provide code to score."
-    # Placeholder logic for code scoring
-    score = f"Code Score for provided code:\n\nSimulated score: {len(code) % 10}/10\n\n(Scoring logic would go here)"
-    return score
+        return _ensure_all_keys({})
+
+    try:
+        client = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+        prompt = ANALYSIS_PROMPT_TEMPLATE.format(code=code)
+
+        tools = [
+            {
+                "name": "code_scores",
+                "description": "Return ONLY the three integer scores (0-100).",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "vulnerability_score": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 100,
+                        },
+                        "style_score": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 100,
+                        },
+                        "quality_score": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 100,
+                        },
+                    },
+                    "required": list(REQUIRED_KEYS),
+                    "additionalProperties": False,
+                },
+            }
+        ]
+
+        resp = client.messages.create(
+            model=MODELS["anthropic"],
+            messages=[{"role": "user", "content": prompt}],
+            system=SYSTEM_MESSAGES["anthropic"],
+            tools=tools,
+            tool_choice={"type": "tool", "name": "code_scores"},
+            max_tokens=64,
+            temperature=0,
+        )
+
+        tool_call = next(c for c in resp.content if c.type == "tool_use")
+        return _ensure_all_keys(tool_call.input)
+
+    except Exception as exc:
+        out = _ensure_all_keys({})
+        out["error"] = f"Anthropic API error: {exc}"
+        return out
+
+def analyze_code_mistral(code: str) -> Dict[str, Any]:
+    if not code:
+        return DEFAULT_SCORES.copy()
+
+    try:
+        client = Mistral(api_key=os.environ["MISTRAL_API_KEY"])
+        prompt = ANALYSIS_PROMPT_TEMPLATE.format(code=code)
+
+        resp = client.chat.complete(
+            model=MODELS["mistral"],
+            messages=[
+                {"role": "system", "content": SYSTEM_MESSAGES["mistral"]},
+                {"role": "user", "content": prompt},
+            ],
+            response_format={"type": "json_object"},
+        )
+
+        return _safe_json_loads(resp.choices[0].message.content)
+
+    except Exception as exc:
+        result = DEFAULT_SCORES.copy()
+        result["error"] = f"Mistral API error: {exc}"
+        return result
+
+
+def analyze_code_openai(code: str) -> Dict[str, Any]:
+    if not code:
+        return DEFAULT_SCORES.copy()
+
+    try:
+        client = OpenAI()  # uses OPENAI_API_KEY from env
+        prompt = ANALYSIS_PROMPT_TEMPLATE.format(code=code)
+
+        resp = client.chat.completions.create(
+            model=MODELS["openai"],
+            messages=[
+                {"role": "system", "content": SYSTEM_MESSAGES["openai"]},
+                {"role": "user", "content": prompt},
+            ],
+            response_format={"type": "json_object"},
+        )
+
+        # Validate via Pydantic (optional but nice)
+        parsed = _safe_json_loads(resp.choices[0].message.content)
+        try:
+            validated = CodeAnalysisResult(**parsed)
+            return validated.model_dump()
+        except ValidationError:
+            # If model returns extra fields or wrong types, fall back to raw
+            return parsed
+
+    except Exception as exc:
+        result = DEFAULT_SCORES.copy()
+        result["error"] = f"OpenAI API error: {exc}"
+        return result
+
+
+# ------------------------------------------------------------------ #
+# Aggregator
+# ------------------------------------------------------------------ #
+
+
+def create_code_score(code: str) -> Dict[str, Any]:
+    if not code:
+        return DEFAULT_SCORES.copy()
+
+    scores_list = [
+        analyze_code_anthropic(code),
+        analyze_code_mistral(code),
+        analyze_code_openai(code),
+    ]
+    valid = [s for s in scores_list if "error" not in s]
+
+    if not valid:
+        result = DEFAULT_SCORES.copy()
+        result["error"] = "All API providers failed"
+        return result
+
+    # Average
+    averaged = {
+        "vulnerability_score": sum(s["vulnerability_score"] for s in valid)
+        // len(valid),
+        "style_score": sum(s["style_score"] for s in valid) // len(valid),
+        "quality_score": sum(s["quality_score"] for s in valid) // len(valid),
+    }
+    return averaged
+
+
+# ------------------------------------------------------------------ #
+# Demo / quick test
+# ------------------------------------------------------------------ #
+
+if __name__ == "__main__":
+    sample = """
+def example_function(x):
+    if x is None:
+        return "Error"
+    return x * 2
+"""
+
+    print("Anthropic →", analyze_code_anthropic(sample))
+    print("Mistral   →", analyze_code_mistral(sample))
+    print("OpenAI    →", analyze_code_openai(sample))
+    print("AVERAGED  →", create_code_score(sample))


### PR DESCRIPTION
This pull request refactors the `create_code_score` function in `src/code_analyzer/scoring.py` to integrate calls to external AI models (Anthropic, Mistral, and OpenAI) for generating code quality metrics.

**Changes include:**

-   Introduced helper functions (`analyze_code_anthropic`, `analyze_code_mistral`, `analyze_code_openai`) to handle API calls to each respective model.
-   Updated the main `create_code_score` function to orchestrate calls to all three models and provide a structure for averaging their scores.
-   Added configuration for API keys (read from environment variables), model names, and a standardized prompt template.
-   Included basic error handling for API initialization and calls.
-   Updated the `if __name__ == "__main__":` block to demonstrate calling the new functions with sample code.

**Note:**

-   The parsing of the AI model responses and the averaging logic are currently placeholders. This will need to be implemented to process the actual JSON output from the models and calculate the final average scores.
-   Requires setting environment variables for API keys (`ANTHROPIC_API_KEY`, `MISTRAL_API_KEY`, `OPENAI_API_KEY`).